### PR TITLE
Remove @examples tags

### DIFF
--- a/R/range_rescale.R
+++ b/R/range_rescale.R
@@ -10,8 +10,6 @@
 #'
 #' @return x rescaled.
 #' @export
-#'
-#' @examples
 range_rescale <- function(x, min_value = NULL, max_value = NULL) {
   if (is.null(min_value)) {
     min_value <- min(x, na.rm = TRUE)

--- a/R/save_json_palette.R
+++ b/R/save_json_palette.R
@@ -13,8 +13,6 @@
 #' the remaining colors. When set the remaining colors get compressed slightly.
 #' @return File is written, nothing is returned.
 #' @export
-#'
-#' @examples
 save_json_palette <- function(file, max, min = 0, n = 10, col_matrix, stretch_first = 2) {
   # Note the ebird palette zero is not in the same gradient as the rest of the
   # palette.

--- a/R/symbolize_raster_data.R
+++ b/R/symbolize_raster_data.R
@@ -12,8 +12,6 @@
 #'
 #' @return invisible()
 #' @export
-#'
-#' @examples
 symbolize_raster_data <- function(tiff = NULL,
                                   png,
                                   col_palette,


### PR DESCRIPTION
This PR will remove @examples tags from 3 files - `range_rescale`, `save_json_palette`, and `symbolize_raster_data`, and fix the R-CMD-check warning about empty @examples tags