### PR TITLE
Move models into package namespace

### DIFF
--- a/R/load_models.R
+++ b/R/load_models.R
@@ -26,7 +26,6 @@ load_models <- function() {
     # This is slow so skipping if it's already done - useful when developing to 
     # avoid having to wait to reload. 
     if(!exists("models") || !is.environment(models) || !all(species$species %in% names(models))) {
-        models <<- new.env(parent = globalenv())
         print(paste("Loading", length(species$species), "models from https://birdflow-science.s3.amazonaws.com/avian_flu/"))
         for (sp in species$species) {
             print(paste0("Loading model for species: ", sp))

--- a/R/load_models.R
+++ b/R/load_models.R
@@ -25,7 +25,7 @@ load_models <- function() {
 
     # This is slow so skipping if it's already done - useful when developing to 
     # avoid having to wait to reload. 
-    if(!exists("models") || !is.environment(models) || !all(species$species %in% names(models))) {
+    if(!all(species$species %in% names(models))) {
         print(paste("Loading", length(species$species), "models from https://birdflow-science.s3.amazonaws.com/avian_flu/"))
         for (sp in species$species) {
             print(paste0("Loading model for species: ", sp))

--- a/R/models.R
+++ b/R/models.R
@@ -1,0 +1,1 @@
+models <- new.env()

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,9 +1,3 @@
-.onLoad <- function(libname, pkgname) {
-    utils::data("species", package = "BirdFlowAPI", envir = parent.env(environment()))
-    utils::data("flow_colors", package = "BirdFlowAPI", envir = parent.env(environment()))
-    load_models()
-}
-
 .ignore_unused_imports <- function() {
     plumber::plumb
 }

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ install.packages("path/to/BirdFlowAPI_x.y.z.tar.gz", repos = NULL, type = "sourc
 devtools::install_github("UMassCDS/BirdFlowAPI")
 ```
 
+## Configure API
+
+The `load_models.R` file defines a function `load_models` that loads the the models of all species. The `load_models` function must be explicitly called while configuring the API. This is done by running `load_models()`.
+
 ## Testing
 
 Run the full test suite:


### PR DESCRIPTION
This PR will:


Move `models` environment into package namespace and don't load them during package load. This is simpler than what we are doing now.

1. In `R/models.R`:  
   `models <- new.env()`

2. In `load_models()`:
   - Drop code that creates the environment.
   - Update conditional for loading models to only check if the models are in the environment.

3. Delete `.on_load()`

4. Add text to readme to explain that models should be explicitly loaded by calling `load_models()` while configuring the API.
