### PR TITLE
Feature/export s3 functions

### DIFF
--- a/R/s3_config.R
+++ b/R/s3_config.R
@@ -1,5 +1,15 @@
 s3_config <- new.env()
 
+#' Set S3 Configuration
+#'
+#' @param access_key AWS access key (default: NULL)
+#' @param secret_key AWS secret key (default: NULL)
+#' @param region AWS region (default: NULL)
+#' @param bucket S3 bucket name (default: NULL)
+#' @param log Enable logging (default: TRUE)
+#' @param log_file_path Path for log file (default: "./flow_debug.log")
+#' @param local_temp_path Path for local temp files (default: "localtmp")
+#' @export
 set_s3_config <- function(access_key = NULL, secret_key = NULL, region = NULL, bucket = NULL, log = TRUE, log_file_path = "./flow_debug.log", local_temp_path = "localtmp") {
   s3_config$access_key <- access_key
   s3_config$secret_key <- secret_key
@@ -20,6 +30,10 @@ set_s3_config <- function(access_key = NULL, secret_key = NULL, region = NULL, b
   s3_config$local_temp_path <- local_temp_path
 }
 
+#' Get S3 Configuration
+#'
+#' @return List of S3 configuration values
+#' @export
 get_s3_config <- function() {
   list(
     access_key = s3_config$access_key %||% Sys.getenv("AWS_ACCESS_KEY_ID", unset = NA),

--- a/inst/plumber/flow/endpoints/predict.R
+++ b/inst/plumber/flow/endpoints/predict.R
@@ -1,5 +1,3 @@
-birdflow_options(collection_url = "https://birdflow-science.s3.amazonaws.com/avian_flu/")
-
 #* Test and generate a plot from a BirdFlow model
 #* @param model_name The model code (e.g., "ambduc")
 #* @post /test_model


### PR DESCRIPTION
This PR will:

- Export the `get_s3_config` and `set_s3_config` functions by adding @export tags in R-oxygen comments
- Remove outdated code from an API endpoint