### PR TITLE
Fix JSON parsing conflict

### DIFF
--- a/R/flow.R
+++ b/R/flow.R
@@ -161,20 +161,32 @@ flow <- function(loc, week, taxa, n, direction = "forward", save_local = FALSE) 
     result <- vector("list", length = n + 1)
     for (i in seq_along(pred_weeks)) {
       result[[i]] <- list(
-        week = pred_weeks[i],
-        url = if (save_local) png_local_paths[i] else png_urls[i],
-        legend = if (save_local) json_local_paths[i] else symbology_urls[i],
-        type = flow_type
+        # week = pred_weeks[i],
+        # url = if (save_local) png_local_paths[i] else png_urls[i],
+        # legend = if (save_local) json_local_paths[i] else symbology_urls[i],
+        # type = flow_type
+        week = jsonlite::unbox(as.integer(pred_weeks[i])),
+        url = jsonlite::unbox(as.character(if (save_local) png_local_paths[i] else png_urls[i])),
+        legend = jsonlite::unbox(as.character(if (save_local) json_local_paths[i] else symbology_urls[i])),
+        type = jsonlite::unbox(as.character(flow_type))
       )
       log_progress(paste0("Cached result for week ", pred_weeks[i], ": url=", result[[i]]$url, ", legend=", result[[i]]$legend))
     }
     log_progress(if (save_local) "Returned cached result from local_temp_path" else "Returned cached result from S3")
     return(
       list(
-        start = list(week = week, taxa = taxa, loc = loc),
-        status = "cached",
+        # start = list(week = week, taxa = taxa, loc = loc),
+        # status = "cached",
+        # result = result,
+        # geotiff = if (save_local) tiff_local_path else paste0(s3_cfg$s3_flow_url, cache_prefix, flow_type, "_", taxa, ".tif")
+        start = list(
+          week = jsonlite::unbox(as.integer(week)),
+          taxa = jsonlite::unbox(as.character(taxa)),
+          location = lapply(strsplit(loc, ";")[[1]], function(pair) as.numeric(strsplit(pair, ",")[[1]]))
+        ),
+        status = jsonlite::unbox("cached"),
         result = result,
-        geotiff = if (save_local) tiff_local_path else paste0(s3_cfg$s3_flow_url, cache_prefix, flow_type, "_", taxa, ".tif")
+        geotiff = jsonlite::unbox(as.character(if (save_local) tiff_local_path else paste0(s3_cfg$s3_flow_url, cache_prefix, flow_type, "_", taxa, ".tif")))
       )
     )
   }
@@ -336,20 +348,32 @@ flow <- function(loc, week, taxa, n, direction = "forward", save_local = FALSE) 
   result <- vector("list", length = n + 1)
   for (i in seq_along(pred_weeks)) {
     result[[i]] <- list(
-      week = pred_weeks[i],
-      url = if (save_local) png_paths[i] else png_urls[i],
-      legend = if (save_local) symbology_paths[i] else symbology_urls[i],
-      type = flow_type
+      # week = pred_weeks[i],
+      # url = if (save_local) png_paths[i] else png_urls[i],
+      # legend = if (save_local) symbology_paths[i] else symbology_urls[i],
+      # type = flow_type
+      week = jsonlite::unbox(as.integer(pred_weeks[i])),
+      url = jsonlite::unbox(as.character(if (save_local) png_paths[i] else png_urls[i])),
+      legend = jsonlite::unbox(as.character(if (save_local) symbology_paths[i] else symbology_urls[i])),
+      type = jsonlite::unbox(as.character(flow_type))
     )
   }
 
   log_progress("Flow function complete. Returning result.")
   return(
     list(
-      start = list(week = week, taxa = taxa, loc = loc),
-      status = "success",
+      # start = list(week = week, taxa = taxa, loc = loc),
+      # status = "success",
+      # result = result,
+      # geotiff = if (save_local) tiff_path else paste0(s3_cfg$s3_flow_url, cache_prefix, flow_type, "_", taxa, ".tif")
+      start = list(
+        week = jsonlite::unbox(as.integer(week)),
+        taxa = jsonlite::unbox(as.character(taxa)),
+        location = lapply(strsplit(loc, ";")[[1]], function(pair) as.numeric(strsplit(pair, ",")[[1]]))
+      ),
+      status = jsonlite::unbox("success"),
       result = result,
-      geotiff = if (save_local) tiff_path else paste0(s3_cfg$s3_flow_url, cache_prefix, flow_type, "_", taxa, ".tif")
+      geotiff = jsonlite::unbox(as.character(if (save_local) tiff_path else paste0(s3_cfg$s3_flow_url, cache_prefix, flow_type, "_", taxa, ".tif")))
     )
   )
 }

--- a/tests/testthat/test-flow.R
+++ b/tests/testthat/test-flow.R
@@ -48,7 +48,8 @@ test_that("output taxa matches input", {
 test_that("output loc matches input", {
   params <- standard_flow_input()
   res <- flow(loc = params$loc, week = params$week, taxa = params$taxa, n = params$n, direction = params$direction, save_local = params$save_local)
-  expect_true(res$start$loc == params$loc)
+  input_loc <- as.numeric(strsplit(params$loc, ",")[[1]])
+  expect_true(all(res$start$location[[1]] == input_loc))
 })
 
 test_that("output week matches input", {

--- a/tests/testthat/test-flow.R
+++ b/tests/testthat/test-flow.R
@@ -123,12 +123,12 @@ test_that("total is not constrained by individual taxa NAs", {
   # Make a total projection
   params$taxa <- "total"
   expect_no_error(total_result <- do.call(flow, params))
-  total <- terra::rast(total_result$geotiff)
+  total <- terra::rast(as.character(total_result$geotiff))
 
   # Same start but for american black duck
   params$taxa <- "ambduc"
   expect_no_error(ambduc_result <- do.call(flow, params))
-  ambduc <- terra::rast(ambduc_result$geotiff)
+  ambduc <- terra::rast(as.character(ambduc_result$geotiff))
 
   # There should be more NA's in the American black duck result than in the total
   ambduc_nas <- terra::values(ambduc) |> is.na() |> sum()


### PR DESCRIPTION
This PR will:

- Refactor the flow function to use `jsonlite` for consistent data formatting in results
  This makes the `flow` output compatible with the frontend, which expects JSON values as strings not lists
  For example - output: `"status": "[success]"`; expected: `"status": "success"`

- Edit the test code to be compatible with the new changes to the output format

- Test the updated code and tests
